### PR TITLE
perf: use \ instead of inv() for solving linear systems

### DIFF
--- a/src/lingradest.jl
+++ b/src/lingradest.jl
@@ -1,5 +1,3 @@
-outer(x, y) = x * y'
-
 """
     lingradest(B1, B2, B3, B4, R1, R2, R3, R4)
 
@@ -26,6 +24,8 @@ Based on the method of Chanteur (ISSI, 1998, Ch. 11).
 - [lingradest.py](https://github.com/spedas/pyspedas/blob/master/pyspedas/analysis/lingradest.py#L5)
 """
 function lingradest(B1, B2, B3, B4, R1, R2, R3, R4)
+    outer(x, y) = x * y'
+
     Rs = (R1, R2, R3, R4)
     Bs = (B1, B2, B3, B4)
 

--- a/src/reciprocal_vector.jl
+++ b/src/reciprocal_vector.jl
@@ -60,5 +60,5 @@ function reciprocal_vector(rα, r0s)
     r_all = (rα, r0s...)
     r̄ = mean(r_all)
     𝐑 = position_tensor(r_all, r̄)
-    return inv(𝐑) * (rα - r̄)
+    return 𝐑 \ (rα - r̄)
 end

--- a/src/timing.jl
+++ b/src/timing.jl
@@ -24,7 +24,7 @@ function ConstantVelocityApproach(positions, times)
     Δts = times[2:end] .- times[1]
     # Calculate position differences relative to first spacecraft
     D = reduce(hcat, [r - positions[1] for r in positions[2:end]])'
-    m = inv(D) * Δts
+    m = D \ Δts
     return m2nV(m)
 end
 


### PR DESCRIPTION
Faster and lower-allocation for the general-N reciprocal_vector path
and CVA, where the inputs are regular Matrix/Vector (not SMatrix).
